### PR TITLE
Add minimal support for building with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,53 @@
+project(json-glib C)
+cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
+
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+
+find_package(PkgConfig REQUIRED)
+find_program(GLIB2_MKENUMS glib-mkenums)
+
+include(GNUInstallDirs)
+include(CheckIncludeFile)
+include(FindGLib)
+
+include_directories(
+  SYSTEM
+  ${GLIB2_INCLUDE_DIRS}
+  ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+add_definitions(${GLIB2_CFLAGS_OTHER})
+CHECK_INCLUDE_FILE(unistd.h HAVE_UNISTD_H)
+if (HAVE_UNISTD_H)
+    add_definitions(-DHAVE_UNISTD_H=1)
+endif()
+
+set(_JSON_EXTERN "__attribute__((visibility(\"default\"))) extern")
+
+set(JSON_MAJOR_VERSION 1)
+set(JSON_MINOR_VERSION 5)
+set(JSON_MICRO_VERSION 1)
+set(JSON_VERSION "${JSON_MAJOR_VERSION}.${JSON_MINOR_VERSION}.${JSON_MICRO_VERSION}")
+
+set(JSON_API_VERSION "1.0")
+set(JSON_API_NAME "${CMAKE_PROJECT_NAME}-${JSON_API_VERSION}")
+
+math(EXPR MINOR_VERSION_IS_EVEN "${JSON_MINOR_VERSION} % 2")
+if(MINOR_VERSION_IS_EVEN EQUAL 0)
+    set(JSON_INTERFACE_AGE ${JSON_MICRO_VERSION})
+else(MINOR_VERSION_IS_EVEN EQUAL 0)
+    set(JSON_INTERFACE_AGE 0)
+endif()
+math(EXPR JSON_BINARY_AGE "(100 * ${JSON_MINOR_VERSION}) + ${JSON_MICRO_VERSION}")
+
+set(JSON_GETTEXT_DOMAIN "${JSON_API_NAME}")
+
+set(JSON_SOVERSION_MAJOR 0)
+math(EXPR JSON_SOVERSION_MINOR "${JSON_BINARY_AGE} - ${JSON_INTERFACE_AGE}")
+set(JSON_SOVERSION "${JSON_SOVERSION_MAJOR}.${JSON_SOVERSION_MINOR}.${JSON_INTERFACE_AGE}")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wcast-align -Wlogical-op -Wmissing-declarations -Wmissing-format-attribute -Wmissing-prototypes -Wmissing-noreturn -Wold-style-definition -Wpointer-arith -Wshadow -Wstrict-prototypes -Wunused -Wno-discarded-qualifiers -Wno-int-conversion -fno-strict-aliasing -Wno-uninitialized -Werror=address -Werror=array-bounds -Werror=empty-body -Werror=format=2 -Werror=implicit -Werror=init-self -Werror=int-to-pointer-cast -Werror=main -Werror=missing-braces -Werror=nested-externs -Werror=nonnull -Werror=pointer-to-int-cast -Werror=return-type -Werror=sequence-point -Werror=trigraphs -Werror=undef -Werror=write-strings")
+set(CMAKE_SHARED_LINKER_FLAGS "${LDFLAGS} -Bsymbolic -z relro -z now")
+
+add_subdirectory(json-glib)

--- a/cmake/FindGLib.cmake
+++ b/cmake/FindGLib.cmake
@@ -1,0 +1,20 @@
+# - try to find the GLIB libraries
+# Once done this will define
+#
+#  GLIB_FOUND - system has GLib
+#  GLIB2_CFLAGS - the GLib CFlags
+#  GLIB2_LIBRARIES - Link these to use GLib
+#
+# Copyright 2008-2010 Pino Toscano, <pino@kde.org>
+# Copyright 2013 Michael Weiser, <michael@weiser.dinsnail.net>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+include(FindPackageHandleStandardArgs)
+
+find_package(PkgConfig REQUIRED)
+
+pkg_check_modules(GLIB2 "glib-2.0" "gobject-2.0" "gio-2.0")
+
+find_package_handle_standard_args(GLib DEFAULT_MSG GLIB2_LIBRARIES GLIB2_CFLAGS)

--- a/json-glib/CMakeLists.txt
+++ b/json-glib/CMakeLists.txt
@@ -1,0 +1,98 @@
+set(JSON_GLIB_HEADERS
+    json-builder.h
+    json-generator.h
+    json-gobject.h
+    json-gvariant.h
+    json-parser.h
+    json-path.h
+    json-reader.h
+    json-types.h
+    json-utils.h
+    json-version-macros.h
+)
+
+set(JSON_GLIB_PUBLIC_HEADERS
+    ${JSON_GLIB_HEADERS}
+    json-enum-types.h
+    json-glib.h
+    json-version.h
+)
+
+set(JSON_GLIB_SRCS
+    json-array.c
+    json-builder.c
+    json-debug.c
+    json-gboxed.c
+    json-generator.c
+    json-gobject.c
+    json-gvariant.c
+    json-node.c
+    json-object.c
+    json-parser.c
+    json-path.c
+    json-reader.c
+    json-scanner.c
+    json-serializable.c
+    json-utils.c
+    json-value.c
+)
+
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/json-enum-types.h
+  COMMAND ${GLIB2_MKENUMS}
+  ARGS
+    --template ${CMAKE_CURRENT_SOURCE_DIR}/json-enum-types.h.in
+    ${JSON_GLIB_HEADERS} > ${CMAKE_CURRENT_SOURCE_DIR}/json-enum-types.h
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDS ${JSON_GLIB_HEADERS}
+          ${CMAKE_CURRENT_SOURCE_DIR}/json-enum-types.h.in
+)
+
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/json-enum-types.c
+  COMMAND ${GLIB2_MKENUMS}
+  ARGS
+    --template ${CMAKE_CURRENT_SOURCE_DIR}/json-enum-types.c.in
+    ${JSON_GLIB_HEADERS} > ${CMAKE_CURRENT_SOURCE_DIR}/json-enum-types.c
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDS ${JSON_GLIB_SRCS}
+          ${CMAKE_CURRENT_SOURCE_DIR}/json-enum-types.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/json-enum-types.c.in
+)
+
+add_definitions(-DG_LOG_DOMAIN="Json")
+add_definitions(-DG_LOG_USE_STRUCTURED=1)
+add_definitions(-DJSON_COMPILATION)
+add_definitions(-DJSON_LOCALEDIR=${CMAKE_INSTALL_LOCALEDIR})
+
+configure_file(json-version.h.in json-version.h @ONLY)
+configure_file(config.h.in config.h)
+
+set(JSON_GLIB_PC "${CMAKE_CURRENT_BINARY_DIR}/${JSON_API_NAME}.pc")
+configure_file(json-glib.pc.in ${JSON_GLIB_PC} @ONLY)
+
+add_library(json_glib SHARED ${JSON_GLIB_SRCS} json-enum-types.c)
+set_target_properties(json_glib PROPERTIES
+    OUTPUT_NAME ${JSON_API_NAME}
+    VERSION ${JSON_VERSION}
+    SOVERSION ${JSON_SOVERSION}
+    FRAMEWORK TRUE
+    PUBLIC_HEADER "${JSON_GLIB_PUBLIC_HEADERS}"
+    C_STANDARD 99
+    C_STANDARD_REQUIRED ON
+    C_EXTENSIONS OFF
+)
+target_link_libraries(json_glib ${GLIB2_LIBRARIES})
+target_include_directories(json_glib PUBLIC include)
+
+install(TARGETS json_glib
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${JSON_API_NAME}
+)
+
+install(FILES
+    ${JSON_GLIB_PC}
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)

--- a/json-glib/config.h.in
+++ b/json-glib/config.h.in
@@ -1,0 +1,11 @@
+/*
+ * Do not edit, your changes will be lost.
+ */
+
+#pragma once
+
+#define GETTEXT_PACKAGE "@JSON_GETTEXT_DOMAIN@"
+
+#cmakedefine HAVE_UNISTD_H @HAVE_UNISTD_H@
+
+#cmakedefine _JSON_EXTERN @_JSON_EXTERN@

--- a/json-glib/json-glib.pc.in
+++ b/json-glib/json-glib.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: JSON-GLib
+Description: JSON Parser for GLib.
+Version: @JSON_VERSION@
+Requires: gio-2.0
+Libs: -L${libdir} -l@JSON_API_NAME@
+Cflags: -I${includedir}/@JSON_API_NAME@


### PR DESCRIPTION
I was investigation to build json-glib with OpenWrt, however, meson and/ninja build
it not supported at the moment.
So I decided to give cmake a trial and created the required infrastructure files.

Please have a look and give feedback whether such an alternative build system
would be a benefit or just noise in your eyes.

Signed-off-by: Michael Heimpold <mhei@heimpold.de>