### PR TITLE
nls: Add meson option to enable/disable NLS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -155,5 +155,7 @@ python3 = import('python').find_installation()
 gen_installed_test = files('build-aux/gen-installed-test.py')
 
 subdir('json-glib')
-subdir('po')
+if get_option('nls')
+  subdir('po')
+endif
 subdir('doc')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,3 +7,6 @@ option('gtk_doc',
 option('man',
        type: 'boolean', value: false,
        description: 'Build the man pages (requires xsltproc)')
+option('nls',
+       type : 'boolean', value : true,
+       description : 'Build native language support')


### PR DESCRIPTION
New meson option to enable/disable Native Language Support.
See https://packages.gentoo.org/useflags/nls for motivation.